### PR TITLE
Update SPIRE and Istio versions. Change selector in registration entries

### DIFF
--- a/25-istio-spire-integration/README.md
+++ b/25-istio-spire-integration/README.md
@@ -30,7 +30,7 @@ Verify that is working:
 ./istioctl version
 ```
 
-The output should show `1.14.0-alpha.0`.
+The output should show `1.15.0`.
 
 2. Deploy SPIRE to cluster
 
@@ -79,7 +79,7 @@ Parent ID        : spiffe://example.org/spire/agent/k8s_psat/demo-cluster/1cd8f0
 Revision         : 0
 TTL              : default
 Selector         : k8s:ns:default
-Selector         : k8s:pod-image:docker.io/istio/examples-bookinfo-details-v1@sha256:18e54f81689035019e1ac78f6d2e6483fcf1d94072d047315ab193cb2ab89ae5
+Selector         : k8s:pod-image:docker.io/istio/examples-bookinfo-details-v1:1.16.2
 Selector         : k8s:pod-label:app:details
 Selector         : k8s:sa:bookinfo-details
 Selector         : unix:uid:1337

--- a/25-istio-spire-integration/demo/create-registration-entries
+++ b/25-istio-spire-integration/demo/create-registration-entries
@@ -16,7 +16,7 @@ kubectl exec -ti spire-server-0 -n spire -c spire-server -- /opt/spire/bin/spire
           -selector k8s:sa:bookinfo-details \
           -selector unix:uid:1337 \
           -selector k8s:pod-label:app:details \
-          -selector k8s:pod-image:docker.io/istio/examples-bookinfo-details-v1@sha256:18e54f81689035019e1ac78f6d2e6483fcf1d94072d047315ab193cb2ab89ae5
+          -selector k8s:pod-image:docker.io/istio/examples-bookinfo-details-v1:1.16.2
 
 # bookinfo ratings
 kubectl exec -ti spire-server-0 -n spire -c spire-server -- /opt/spire/bin/spire-server entry create \
@@ -26,7 +26,7 @@ kubectl exec -ti spire-server-0 -n spire -c spire-server -- /opt/spire/bin/spire
           -selector k8s:ns:default \
           -selector k8s:sa:bookinfo-ratings \
           -selector unix:uid:1337 \
-          -selector k8s:pod-image:docker.io/istio/examples-bookinfo-ratings-v1@sha256:5fbfd3a14fff229f15e689d07e5214bc5eb1e929766e45eda761cbc9ef7a5589
+          -selector k8s:pod-image:docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
 
 # bookinfo reviews
 kubectl exec -ti spire-server-0 -n spire -c spire-server -- /opt/spire/bin/spire-server entry create \
@@ -47,7 +47,7 @@ kubectl exec -ti spire-server-0 -n spire -c spire-server -- /opt/spire/bin/spire
           -selector k8s:sa:bookinfo-productpage \
           -selector unix:uid:1337 \
           -selector k8s:pod-label:app:productpage \
-          -selector k8s:pod-image:docker.io/istio/examples-bookinfo-productpage-v1@sha256:63ac3b4fb6c3ba395f5d044b0e10bae513afb34b9b7d862b3a7c3de7e0686667
+          -selector k8s:pod-image:docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
 
 # istio ingress-gateway
 kubectl exec -ti spire-server-0 -n spire -c spire-server -- /opt/spire/bin/spire-server entry create \

--- a/25-istio-spire-integration/demo/download-istioctl
+++ b/25-istio-spire-integration/demo/download-istioctl
@@ -6,9 +6,9 @@ if [[ -z $1 ]]; then
 fi
 
 if [ "$1" = "macos" ]; then
-    wget -c https://github.com/istio/istio/releases/download/1.14.0-alpha.0/istioctl-1.14.0-alpha.0-osx.tar.gz -O - | tar -xz
+    wget -c https://github.com/istio/istio/releases/download/1.15.0/istioctl-1.15.0-osx.tar.gz -O - | tar -xz
 fi
 
 if [ "$1" = "linux" ]; then
-    wget -c https://github.com/istio/istio/releases/download/1.14.0-alpha.0/istioctl-1.14.0-alpha.0-linux-amd64.tar.gz -O - | tar -xz
+    wget -c https://github.com/istio/istio/releases/download/1.15.0/istioctl-1.15.0-linux-amd64.tar.gz -O - | tar -xz
 fi

--- a/25-istio-spire-integration/demo/istio/istio-config.yaml
+++ b/25-istio-spire-integration/demo/istio/istio-config.yaml
@@ -29,6 +29,7 @@ spec:
             - name: workload-socket
               csi:
                 driver: "csi.spiffe.io"
+                readOnly: true
   components:
     ingressGateways:
       - name: istio-ingressgateway
@@ -46,6 +47,7 @@ spec:
                     name: workload-socket
                     csi:
                       driver: "csi.spiffe.io"
+                      readOnly: true
                 - path: spec.template.spec.containers.[name:istio-proxy].volumeMounts.[name:workload-socket]
                   value:
                     name: workload-socket

--- a/25-istio-spire-integration/demo/spire/agent-daemonset.yaml
+++ b/25-istio-spire-integration/demo/spire/agent-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:1.2.3
+          image: gcr.io/spiffe-io/spire-agent:1.4.3
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config
@@ -57,7 +57,7 @@ spec:
             periodSeconds: 5
         # This is the container which runs the SPIFFE CSI driver.
         - name: spiffe-csi-driver
-          image: ghcr.io/spiffe/spiffe-csi-driver:0.1.0
+          image: ghcr.io/spiffe/spiffe-csi-driver:0.2.0
           imagePullPolicy: IfNotPresent
           args: [
               "-node-id", "CSI_NODE",

--- a/25-istio-spire-integration/demo/spire/server-statefulset.yaml
+++ b/25-istio-spire-integration/demo/spire/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:1.2.3
+          image: gcr.io/spiffe-io/spire-server:1.4.3
           args:
             - -config
             - /run/spire/config/server.conf


### PR DESCRIPTION
Changed selector in registration entries for the the bookinfo identities in order to use docker image version instead of the SHA-256 (related to #60, the docker images used seemingly had a different SHA and thus the attestation was failing and the example wasn't working on that instance)

Also changed configs to use latest SPIRE, Istio, and CSI driver versions.

Signed-off-by: Max Lambrecht <max.lambrecht@hpe.com>